### PR TITLE
Add removeRelativePath feature and parameter

### DIFF
--- a/src/main/java/com/outbrain/ci/friendly/flatten/maven/plugin/FlattenMojo.java
+++ b/src/main/java/com/outbrain/ci/friendly/flatten/maven/plugin/FlattenMojo.java
@@ -40,6 +40,9 @@ public class FlattenMojo extends AbstractCiFriendlyMojo {
   @Parameter(property = "changelist")
   private String changeList;
 
+  @Parameter(property = "removeRelativePath", defaultValue = "false")
+  private String removeRelativePath;
+
   private final PomVisitorImpl pomVisitor = new PomVisitorImpl();
 
   /**
@@ -48,7 +51,7 @@ public class FlattenMojo extends AbstractCiFriendlyMojo {
   public void execute() throws MojoExecutionException {
     final String originalPom = readPom();
     final String revision = getRevision();
-    final String modifiedPom = pomVisitor.visit(originalPom, revision, sha1, changeList);
+    final String modifiedPom = pomVisitor.visit(originalPom, revision, sha1, changeList, Boolean.valueOf(removeRelativePath));
     if (originalPom.equals(modifiedPom)) {
       getLog().info("Pom does not have any CI friendly properties");
     } else {

--- a/src/main/java/com/outbrain/ci/friendly/flatten/maven/plugin/visitor/PomVisitorImpl.java
+++ b/src/main/java/com/outbrain/ci/friendly/flatten/maven/plugin/visitor/PomVisitorImpl.java
@@ -1,8 +1,12 @@
 package com.outbrain.ci.friendly.flatten.maven.plugin.visitor;
 
+import java.util.regex.Pattern;
+
 public class PomVisitorImpl {
 
-  public String visit(final String originalPom, final String revision, final String sha1, final String changeList){
+  private static Pattern path = Pattern.compile("<relativePath>.+</relativePath>");
+	
+  public String visit(final String originalPom, final String revision, final String sha1, final String changeList, Boolean removeRelativePath){
     String modified;
     modified = originalPom.replace("${revision}", revision);
     if (modified.contains("${sha1}")) {
@@ -13,6 +17,10 @@ public class PomVisitorImpl {
       modified = modified.replace("${changelist}", changeList != null ? changeList : "");
     }
 
+    if(removeRelativePath) {
+    	modified = path.matcher(modified).replaceAll("");
+    }
+    
     return modified;
   }
 }

--- a/src/test/java/com/outbrain/ci/friendly/flatten/maven/plugin/visitor/PomVisitorImplTest.java
+++ b/src/test/java/com/outbrain/ci/friendly/flatten/maven/plugin/visitor/PomVisitorImplTest.java
@@ -26,9 +26,24 @@ public class PomVisitorImplTest {
     final File resultPomFile = new File("src/test/resources/all/result-test-pom.xml");
     final String resultPom = readPom(resultPomFile);
 
-    final String modifiedPom = visitor.visit(originalPom, "test-revision", "test-sha1", "test-changelist");
-
+    final String modifiedPom = visitor.visit(originalPom, "test-revision", "test-sha1", "test-changelist", false);
+    
     assertEquals(resultPom, modifiedPom);
+    
+  }
+  
+  @Test
+  public void testFullModifyNoPathPom() throws Exception {
+	final File originalPomFile = new File("src/test/resources/all/original-removepath-test-pom.xml");
+	final String originalPom = readPom(originalPomFile);
+
+	final File resultPomFile = new File("src/test/resources/all/result-removepath-test-pom.xml");
+	final String resultPom = readPom(resultPomFile);
+
+	final String modifiedPom = visitor.visit(originalPom, "test-revision", "test-sha1", "test-changelist", true);
+	
+	assertEquals(resultPom, modifiedPom);
+	    
   }
 
   @Test
@@ -39,7 +54,7 @@ public class PomVisitorImplTest {
     final File resultPomFile = new File("src/test/resources/revision/result-test-pom.xml");
     final String resultPom = readPom(resultPomFile);
 
-    final String modifiedPom = visitor.visit(originalPom, "test-revision", null, null);
+    final String modifiedPom = visitor.visit(originalPom, "test-revision", null, null, false);
 
     assertEquals(resultPom, modifiedPom);
   }
@@ -52,7 +67,7 @@ public class PomVisitorImplTest {
     final File resultPomFile = new File("src/test/resources/revision.and.sha1/result-test-pom.xml");
     final String resultPom = readPom(resultPomFile);
 
-    final String modifiedPom = visitor.visit(originalPom, "test-revision", null, null);
+    final String modifiedPom = visitor.visit(originalPom, "test-revision", null, null, false);
 
     assertEquals(resultPom, modifiedPom);
   }
@@ -65,7 +80,7 @@ public class PomVisitorImplTest {
     final File resultPomFile = new File("src/test/resources/revision.and.changelist/result-test-pom.xml");
     final String resultPom = readPom(resultPomFile);
 
-    final String modifiedPom = visitor.visit(originalPom, "test-revision", null, null);
+    final String modifiedPom = visitor.visit(originalPom, "test-revision", null, null, false);
 
     assertEquals(resultPom, modifiedPom);
   }

--- a/src/test/resources/all/original-removepath-test-pom.xml
+++ b/src/test/resources/all/original-removepath-test-pom.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--suppress ALL -->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>com.outbrain.test</groupId>
+  <artifactId>test-lib</artifactId>
+
+  <parent>
+    <groupId>com.outbrain.test</groupId>
+    <artifactId>parent-modules-pom</artifactId>
+    <version>${revision}.${sha1}.${changelist}</version>
+    <relativePath>..</relativePath>
+  </parent>
+
+  <packaging>pom</packaging>
+
+  <modules>
+    <module>ModuleA</module>
+  </modules>
+</project>

--- a/src/test/resources/all/result-removepath-test-pom.xml
+++ b/src/test/resources/all/result-removepath-test-pom.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--suppress ALL -->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>com.outbrain.test</groupId>
+  <artifactId>test-lib</artifactId>
+
+  <parent>
+    <groupId>com.outbrain.test</groupId>
+    <artifactId>parent-modules-pom</artifactId>
+    <version>test-revision.test-sha1.test-changelist</version>
+    
+  </parent>
+
+  <packaging>pom</packaging>
+
+  <modules>
+    <module>ModuleA</module>
+  </modules>
+</project>


### PR DESCRIPTION
## 📑 Description
When we have a multi-POM project and want to have a version only in one base POM we have to use the **relativePath** tag.  When POM with this tag is copied to the repo, we need to eliminate it. flatten-maven-plugin does this in some modes but if we use ci-friendly-flatten-maven-plugin this can be a problem. So I implement the additional feature to remove it from the target POM.

To activate it **removeRelativePath** parameter is added.

	<plugin>
            <groupId>com.outbrain.swinfra</groupId>
            <artifactId>ci-friendly-flatten-maven-plugin</artifactId>
            <version>1.0.15-SNAPSHOT</version>
            <executions>
              <execution>
                <goals>
                  <!-- Ensure proper cleanup. Will run on clean phase-->
                  <goal>clean</goal>
                  <!-- Enable ci-friendly version resolution. Will run on process-resources phase-->
                  <goal>flatten</goal>
                  
                </goals>
                <configuration>
                  <removeRelativePath>true</removeRelativePath>
                </configuration>
              </execution>
            </executions>
        </plugin>

