### PR TITLE
feat: set project.originalModel after flattening

### DIFF
--- a/src/main/java/com/outbrain/ci/friendly/flatten/maven/plugin/FlattenMojo.java
+++ b/src/main/java/com/outbrain/ci/friendly/flatten/maven/plugin/FlattenMojo.java
@@ -4,6 +4,8 @@ package com.outbrain.ci.friendly.flatten.maven.plugin;
 import com.outbrain.ci.friendly.flatten.maven.plugin.visitor.PomVisitorImpl;
 import org.apache.commons.io.FileUtils;
 import org.apache.maven.execution.MavenSession;
+import org.apache.maven.model.Model;
+import org.apache.maven.model.io.xpp3.MavenXpp3Reader;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugins.annotations.LifecyclePhase;
 import org.apache.maven.plugins.annotations.Mojo;
@@ -14,6 +16,7 @@ import org.apache.maven.project.MavenProject;
 import java.io.File;
 import java.io.FileWriter;
 import java.io.IOException;
+import java.nio.file.Files;
 import java.util.Properties;
 
 
@@ -55,6 +58,16 @@ public class FlattenMojo extends AbstractCiFriendlyMojo {
       getLog().info("Replacing CI friendly properties for project " + this.project.getId() + "...");
       final File ciFriendlyPomFile = writePom(modifiedPom);
       this.project.setPomFile(ciFriendlyPomFile);
+      this.project.setOriginalModel(getModel(ciFriendlyPomFile));
+    }
+  }
+
+  private Model getModel(File file) throws MojoExecutionException {
+    MavenXpp3Reader reader = new MavenXpp3Reader();
+    try {
+      return reader.read(Files.newInputStream(file.toPath()));
+    } catch (Exception e) {
+      throw new MojoExecutionException("Error reading raw model.", e);
     }
   }
 


### PR DESCRIPTION
it is required for shade plugin

<!-- 
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below -->
Closes #42

## 📑 Description
set project.originalModel after flattening that is required for shade plugin to work after flattening

<!-- You can also choose to add a list of changes and if they have been completed or not by using the markdown to-do list syntax
- [ ] Not Completed
- [x] Completed
-->

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [x] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required
- [x] All the tests have passed

## ℹ Additional Information
<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->
