### PR TITLE
Bumping multiple versions

### DIFF
--- a/.github/workflows/compile.yml
+++ b/.github/workflows/compile.yml
@@ -10,11 +10,11 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
-      - name: Set up openjdk 8
+      - name: Set up openjdk 17
         uses: actions/setup-java@v3
         with:
           distribution: 'temurin'
-          java-version: '8'
+          java-version: '17'
 
       - name: Build with Maven
         run: mvn clean install

--- a/pom.xml
+++ b/pom.xml
@@ -47,33 +47,27 @@
     </snapshotRepository>
   </distributionManagement>
 
-  <prerequisites>
-    <maven>${mavenVersion}</maven>
-  </prerequisites>
   <properties>
-    <java.compiler.source>1.8</java.compiler.source>
-    <java.compiler.target>1.8</java.compiler.target>
+    <maven.compiler.release>8</maven.compiler.release>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <mavenVersion>3.2.5</mavenVersion>
-    <maven-dependency-tree.version>2.2</maven-dependency-tree.version>
-    <plexus-utils.version>3.3.0</plexus-utils.version>
-    <maven-artifact-transfer.version>0.9.0</maven-artifact-transfer.version>
-    <assertj-core.version>3.16.1</assertj-core.version>
-    <maven-plugin-annotations.version>3.4</maven-plugin-annotations.version>
-    <maven-plugin-api.version>3.5.3</maven-plugin-api.version>
-    <maven-invoker-plugin.version>3.2.1</maven-invoker-plugin.version>
-    <maven-plugin-plugin.version>3.5.1</maven-plugin-plugin.version>
-    <maven-release-plugin.version>3.0.0-M4</maven-release-plugin.version>
-    <maven-source-plugin.version>2.2.1</maven-source-plugin.version>
-    <maven-javadoc-plugin.version>3.2.0</maven-javadoc-plugin.version>
-    <maven-gpg-plugin.version>1.6</maven-gpg-plugin.version>
+    <mavenVersion>3.9.2</mavenVersion>
+    <maven-dependency-tree.version>3.2.1</maven-dependency-tree.version>
+    <plexus-utils.version>3.5.1</plexus-utils.version>
+    <maven-artifact-transfer.version>0.13.1</maven-artifact-transfer.version>
+    <maven-plugin-annotations.version>3.9.0</maven-plugin-annotations.version>
+    <maven-invoker-plugin.version>3.6.0</maven-invoker-plugin.version>
+    <maven-plugin-plugin.version>3.9.0</maven-plugin-plugin.version>
+    <maven-release-plugin.version>3.0.1</maven-release-plugin.version>
+    <maven-source-plugin.version>3.3.0</maven-source-plugin.version>
+    <maven-javadoc-plugin.version>3.5.0</maven-javadoc-plugin.version>
+    <maven-gpg-plugin.version>3.1.0</maven-gpg-plugin.version>
     <skipSign>true</skipSign>
-    <nexus-staging-maven-plugin.version>1.6.7</nexus-staging-maven-plugin.version>
-    <maven-source-plugin.version.a>2.2.1</maven-source-plugin.version.a>
-    <maven-compiler-plugin.version>3.5.1</maven-compiler-plugin.version>
-    <maven-scm.version>1.11.2</maven-scm.version>
-    <maven-surefire-plugin.version>3.0.0-M5</maven-surefire-plugin.version>
-    <junit.version>4.12</junit.version>
+    <nexus-staging-maven-plugin.version>1.6.13</nexus-staging-maven-plugin.version>
+    <maven-compiler-plugin.version>3.11.0</maven-compiler-plugin.version>
+    <maven-scm.version>2.0.1</maven-scm.version>
+    <maven-surefire-plugin.version>3.1.2</maven-surefire-plugin.version>
+    <junit-jupiter-engine.version>5.9.3</junit-jupiter-engine.version>
+    <junit-platform-runner.version>1.9.3</junit-platform-runner.version>
   </properties>
 
   <dependencies>
@@ -81,11 +75,13 @@
       <groupId>org.apache.maven</groupId>
       <artifactId>maven-model</artifactId>
       <version>${mavenVersion}</version>
+      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.maven</groupId>
       <artifactId>maven-model-builder</artifactId>
       <version>${mavenVersion}</version>
+      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.maven.shared</groupId>
@@ -96,16 +92,19 @@
       <groupId>org.apache.maven</groupId>
       <artifactId>maven-artifact</artifactId>
       <version>${mavenVersion}</version>
+      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.maven</groupId>
       <artifactId>maven-core</artifactId>
       <version>${mavenVersion}</version>
+      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.maven</groupId>
       <artifactId>maven-plugin-api</artifactId>
       <version>${mavenVersion}</version>
+      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>org.codehaus.plexus</groupId>
@@ -123,20 +122,21 @@
       <version>${maven-plugin-annotations.version}</version>
     </dependency>
     <dependency>
-      <groupId>org.apache.maven</groupId>
-      <artifactId>maven-plugin-api</artifactId>
-      <version>${maven-plugin-api.version}</version>
-    </dependency>
-    <dependency>
       <groupId>org.apache.maven.plugins</groupId>
       <artifactId>maven-scm-plugin</artifactId>
       <version>${maven-scm.version}</version>
     </dependency>
 
     <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
-      <version>${junit.version}</version>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-engine</artifactId>
+      <version>${junit-jupiter-engine.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.platform</groupId>
+      <artifactId>junit-platform-runner</artifactId>
+      <version>${junit-platform-runner.version}</version>
       <scope>test</scope>
     </dependency>
   </dependencies>
@@ -166,8 +166,7 @@
         <artifactId>maven-compiler-plugin</artifactId>
         <version>${maven-compiler-plugin.version}</version>
         <configuration>
-          <source>${java.compiler.source}</source>
-          <target>${java.compiler.target}</target>
+          <release>${maven.compiler.release}</release>
         </configuration>
         <executions>
           <!-- Replacing default-compile as it is treated specially by maven -->

--- a/src/test/java/com/outbrain/ci/friendly/flatten/maven/plugin/visitor/PomVisitorImplTest.java
+++ b/src/test/java/com/outbrain/ci/friendly/flatten/maven/plugin/visitor/PomVisitorImplTest.java
@@ -1,8 +1,8 @@
 package com.outbrain.ci.friendly.flatten.maven.plugin.visitor;
 
 import org.apache.commons.io.FileUtils;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.io.File;
 import java.io.IOException;
@@ -13,7 +13,7 @@ import static org.junit.Assert.assertEquals;
 public class PomVisitorImplTest {
   private PomVisitorImpl visitor;
 
-  @Before
+  @BeforeEach
   public void before() {
     visitor = new PomVisitorImpl();
   }

--- a/src/test/java/com/outbrain/ci/friendly/flatten/maven/plugin/visitor/VersionPrefixTest.java
+++ b/src/test/java/com/outbrain/ci/friendly/flatten/maven/plugin/visitor/VersionPrefixTest.java
@@ -3,9 +3,10 @@ package com.outbrain.ci.friendly.flatten.maven.plugin.visitor;
 
 import com.outbrain.ci.friendly.flatten.maven.plugin.VersionUtil;
 import org.apache.maven.plugin.MojoExecutionException;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class VersionPrefixTest {
 
@@ -27,9 +28,9 @@ public class VersionPrefixTest {
     assertEquals("4.0.0", version);
   }
 
-  @Test(expected = MojoExecutionException.class)
-  public void testVersionMatcherUnmatched() throws MojoExecutionException {
-    VersionUtil.getVersion("V4.0.0", "Z");
+  @Test
+  public void testVersionMatcherUnmatched() {
+    assertThrows(MojoExecutionException.class, () -> VersionUtil.getVersion("V4.0.0", "Z"));
   }
 
 


### PR DESCRIPTION
Bump maven version to 3.9.2.
Remove prerequisite maven version.
Upgrade to junit 5.
Bump plugin versions.

Closes #53 

## 📑 Description
Bump multiple versions to avoid plugin validation errors.

## ✅ Checks
- [ ] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required
- [ ] All the tests have passed

